### PR TITLE
Fix dropped jobs with runonce

### DIFF
--- a/src/Runner.Server/Models/Session.cs
+++ b/src/Runner.Server/Models/Session.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Cryptography;
 using System.Timers;
 using GitHub.DistributedTask.WebApi;
@@ -18,5 +19,6 @@ namespace Runner.Server.Models
 
         public Timer Timer {get; set;}
         public Timer JobTimer {get; set;}
+        public Action DropMessage { get; set; }
     }
 }


### PR DESCRIPTION
The runner skips deletemessage, this fix requeues the job if another GetMessage is callded without a deletemessage.