### PR TITLE
Run localcheckout asynchronously on the client

### DIFF
--- a/src/Runner.Client/Program.cs
+++ b/src/Runner.Client/Program.cs
@@ -1172,73 +1172,44 @@ namespace Runner.Client
                                             // }
                                         }
                                         if(line == "event: repodownload") {
-                                            var repodownload = new MultipartFormDataContent();
-                                            List<Stream> streamsToDispose = new List<Stream>();
-                                            try {
+                                            Task.Run(async () => {
+                                                var repodownload = new MultipartFormDataContent();
+                                                List<Stream> streamsToDispose = new List<Stream>();
                                                 try {
-                                                    EventHandler<ProcessDataReceivedEventArgs> handleoutput = (s, e) => {
-                                                        var files = e.Data.Split('\0');
-                                                        foreach(var file in files) {
-                                                            if(file == "") break;
-                                                            var modeend = file.IndexOf(' ');
-                                                            var filebeg = file.IndexOf('\t') + 1;
-                                                            var mode = modeend == 6 ? file.Substring(3, modeend - 3) : "644";
-                                                            var filename = file.Substring(filebeg);
-                                                            try {
-                                                                var fs = File.OpenRead(Path.Combine(parameters.directory ?? ".", filename));
-                                                                streamsToDispose.Add(fs);
-                                                                repodownload.Add(new StreamContent(fs), mode + ":" + filename, filename);
-                                                            }
-                                                            catch {
-
-                                                            }
-                                                        }
-                                                    };
-                                                    GitHub.Runner.Sdk.ProcessInvoker gitinvoker = new GitHub.Runner.Sdk.ProcessInvoker(new TraceWriter(parameters.verbose));
-                                                    gitinvoker.OutputDataReceived += handleoutput;
-                                                    var binpath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-                                                    var git = WhichUtil.Which("git", true);
-                                                    await gitinvoker.ExecuteAsync(parameters.directory ?? Path.GetFullPath("."), git, "ls-files -z -s", new Dictionary<string, string>(), source.Token);
-                                                    gitinvoker = new GitHub.Runner.Sdk.ProcessInvoker(new TraceWriter(parameters.verbose));
-                                                    gitinvoker.OutputDataReceived += (s, e) => {
-                                                        var files = e.Data.Split('\0');
-                                                        foreach(var filename in files) {
-                                                            if(filename == "") break;
-                                                            var relpath = Path.Combine(parameters.directory ?? ".", filename);
-                                                            var mode = "644";
-                                                            if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
+                                                    try {
+                                                        EventHandler<ProcessDataReceivedEventArgs> handleoutput = (s, e) => {
+                                                            var files = e.Data.Split('\0');
+                                                            foreach(var file in files) {
+                                                                if(file == "") break;
+                                                                var modeend = file.IndexOf(' ');
+                                                                var filebeg = file.IndexOf('\t') + 1;
+                                                                var mode = modeend == 6 ? file.Substring(3, modeend - 3) : "644";
+                                                                var filename = file.Substring(filebeg);
                                                                 try {
-                                                                    var finfo = new Mono.Unix.UnixFileInfo(relpath);
-                                                                    if(finfo.FileAccessPermissions.HasFlag(Mono.Unix.FileAccessPermissions.UserExecute)) {
-                                                                        mode = "755";
-                                                                    }
+                                                                    var fs = File.OpenRead(Path.Combine(parameters.directory ?? ".", filename));
+                                                                    streamsToDispose.Add(fs);
+                                                                    repodownload.Add(new StreamContent(fs), mode + ":" + filename, filename);
                                                                 }
                                                                 catch {
 
                                                                 }
                                                             }
-                                                            try {
-                                                                var fs = File.OpenRead(relpath);
-                                                                streamsToDispose.Add(fs);
-                                                                repodownload.Add(new StreamContent(fs), mode + ":" + filename, filename);
-                                                            } catch {
-
-                                                            }
-                                                        }
-                                                    };
-                                                    await gitinvoker.ExecuteAsync(parameters.directory ?? Path.GetFullPath("."), git, "ls-files -z -o --exclude-standard", new Dictionary<string, string>(), source.Token);
-                                                    if(!parameters.NoCopyGitDir) {
-                                                        // Copy .git dir if it exists (not working with git worktree) https://github.com/ChristopherHX/runner.server/issues/34
-                                                        var gitdir = Path.Combine(parameters.directory ?? ".", ".git");
-                                                        if(Directory.Exists(gitdir)) {
-                                                            foreach(var w in Directory.EnumerateFiles(gitdir, "*", new EnumerationOptions { RecurseSubdirectories = true, MatchType = MatchType.Win32, AttributesToSkip = 0, IgnoreInaccessible = true })) {
-                                                                var relpath = Path.GetRelativePath(parameters.directory ?? ".", w).Replace('\\', '/');
-                                                                var file = File.OpenRead(w);
-                                                                streamsToDispose.Add(file);
+                                                        };
+                                                        GitHub.Runner.Sdk.ProcessInvoker gitinvoker = new GitHub.Runner.Sdk.ProcessInvoker(new TraceWriter(parameters.verbose));
+                                                        gitinvoker.OutputDataReceived += handleoutput;
+                                                        var binpath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                                                        var git = WhichUtil.Which("git", true);
+                                                        await gitinvoker.ExecuteAsync(parameters.directory ?? Path.GetFullPath("."), git, "ls-files -z -s", new Dictionary<string, string>(), source.Token);
+                                                        gitinvoker = new GitHub.Runner.Sdk.ProcessInvoker(new TraceWriter(parameters.verbose));
+                                                        gitinvoker.OutputDataReceived += (s, e) => {
+                                                            var files = e.Data.Split('\0');
+                                                            foreach(var filename in files) {
+                                                                if(filename == "") break;
+                                                                var relpath = Path.Combine(parameters.directory ?? ".", filename);
                                                                 var mode = "644";
                                                                 if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
                                                                     try {
-                                                                        var finfo = new Mono.Unix.UnixFileInfo(w);
+                                                                        var finfo = new Mono.Unix.UnixFileInfo(relpath);
                                                                         if(finfo.FileAccessPermissions.HasFlag(Mono.Unix.FileAccessPermissions.UserExecute)) {
                                                                             mode = "755";
                                                                         }
@@ -1247,46 +1218,77 @@ namespace Runner.Client
 
                                                                     }
                                                                 }
-                                                                repodownload.Add(new StreamContent(file), mode + ":" + relpath, relpath);
+                                                                try {
+                                                                    var fs = File.OpenRead(relpath);
+                                                                    streamsToDispose.Add(fs);
+                                                                    repodownload.Add(new StreamContent(fs), mode + ":" + filename, filename);
+                                                                } catch {
+
+                                                                }
+                                                            }
+                                                        };
+                                                        await gitinvoker.ExecuteAsync(parameters.directory ?? Path.GetFullPath("."), git, "ls-files -z -o --exclude-standard", new Dictionary<string, string>(), source.Token);
+                                                        if(!parameters.NoCopyGitDir) {
+                                                            // Copy .git dir if it exists (not working with git worktree) https://github.com/ChristopherHX/runner.server/issues/34
+                                                            var gitdir = Path.Combine(parameters.directory ?? ".", ".git");
+                                                            if(Directory.Exists(gitdir)) {
+                                                                foreach(var w in Directory.EnumerateFiles(gitdir, "*", new EnumerationOptions { RecurseSubdirectories = true, MatchType = MatchType.Win32, AttributesToSkip = 0, IgnoreInaccessible = true })) {
+                                                                    var relpath = Path.GetRelativePath(parameters.directory ?? ".", w).Replace('\\', '/');
+                                                                    var file = File.OpenRead(w);
+                                                                    streamsToDispose.Add(file);
+                                                                    var mode = "644";
+                                                                    if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
+                                                                        try {
+                                                                            var finfo = new Mono.Unix.UnixFileInfo(w);
+                                                                            if(finfo.FileAccessPermissions.HasFlag(Mono.Unix.FileAccessPermissions.UserExecute)) {
+                                                                                mode = "755";
+                                                                            }
+                                                                        }
+                                                                        catch {
+
+                                                                        }
+                                                                    }
+                                                                    repodownload.Add(new StreamContent(file), mode + ":" + relpath, relpath);
+                                                                }
                                                             }
                                                         }
+                                                    } catch {
+                                                        foreach(var fstream in streamsToDispose) {
+                                                            await fstream.DisposeAsync();
+                                                        }
+                                                        streamsToDispose.Clear();
+                                                        repodownload.Dispose();
+                                                        repodownload = new MultipartFormDataContent();
                                                     }
-                                                } catch {
+                                                    if(streamsToDispose.Count == 0) {
+                                                        foreach(var w in Directory.EnumerateFiles(parameters.directory ?? ".", "*", new EnumerationOptions { RecurseSubdirectories = true, MatchType = MatchType.Win32, AttributesToSkip = 0, IgnoreInaccessible = true })) {
+                                                            var relpath = Path.GetRelativePath(parameters.directory ?? ".", w).Replace('\\', '/');
+                                                            var file = File.OpenRead(w);
+                                                            streamsToDispose.Add(file);
+                                                            var mode = "644";
+                                                            if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
+                                                                try {
+                                                                    var finfo = new Mono.Unix.UnixFileInfo(w);
+                                                                    if(finfo.FileAccessPermissions.HasFlag(Mono.Unix.FileAccessPermissions.UserExecute)) {
+                                                                        mode = "755";
+                                                                    }
+                                                                }
+                                                                catch {
+
+                                                                }
+                                                            }
+                                                            repodownload.Add(new StreamContent(file), mode + ":" + relpath, relpath);
+                                                        }
+                                                    }
+                                                    repodownload.Headers.ContentType.MediaType = "application/octet-stream";
+                                                    await client.PostAsync(parameters.server + data, repodownload, token);
+                                                } finally {
                                                     foreach(var fstream in streamsToDispose) {
                                                         await fstream.DisposeAsync();
                                                     }
-                                                    streamsToDispose.Clear();
                                                     repodownload.Dispose();
-                                                    repodownload = new MultipartFormDataContent();
                                                 }
-                                                if(streamsToDispose.Count == 0) {
-                                                    foreach(var w in Directory.EnumerateFiles(parameters.directory ?? ".", "*", new EnumerationOptions { RecurseSubdirectories = true, MatchType = MatchType.Win32, AttributesToSkip = 0, IgnoreInaccessible = true })) {
-                                                        var relpath = Path.GetRelativePath(parameters.directory ?? ".", w).Replace('\\', '/');
-                                                        var file = File.OpenRead(w);
-                                                        streamsToDispose.Add(file);
-                                                        var mode = "644";
-                                                        if(!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)) {
-                                                            try {
-                                                                var finfo = new Mono.Unix.UnixFileInfo(w);
-                                                                if(finfo.FileAccessPermissions.HasFlag(Mono.Unix.FileAccessPermissions.UserExecute)) {
-                                                                    mode = "755";
-                                                                }
-                                                            }
-                                                            catch {
-
-                                                            }
-                                                        }
-                                                        repodownload.Add(new StreamContent(file), mode + ":" + relpath, relpath);
-                                                    }
-                                                }
-                                                repodownload.Headers.ContentType.MediaType = "application/octet-stream";
-                                                await client.PostAsync(parameters.server + data, repodownload, token);
-                                            } finally {
-                                                foreach(var fstream in streamsToDispose) {
-                                                    await fstream.DisposeAsync();
-                                                }
-                                                repodownload.Dispose();
-                                            }
+                                            });
                                         }
                                         if(line == "event: workflow") {
                                             


### PR DESCRIPTION
No longer timeout localcheckout if multiple jobs are using it parallel.