### PR TITLE
Improve job names

### DIFF
--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -1740,8 +1740,10 @@ namespace Runner.Server.Controllers
                                                 var displaySuffix = new StringBuilder();
                                                 int z = 0;
                                                 foreach (var mk in item) {
-                                                    displaySuffix.Append(z++ == 0 ? "(" : ", ");
-                                                    displaySuffix.Append(mk);
+                                                    if(!string.IsNullOrEmpty(mk)) {
+                                                        displaySuffix.Append(z++ == 0 ? "(" : ", ");
+                                                        displaySuffix.Append(mk);
+                                                    }
                                                 }
                                                 if(z > 0) {
                                                     displaySuffix.Append( ")");

--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -1818,10 +1818,7 @@ namespace Runner.Server.Controllers
                                                 }
                                                 var next = jobTotal > 1 ? new JobItem() { name = jobitem.name, Id = Guid.NewGuid() } : jobitem;
                                                 Func<string, string> defJobName = jobname => string.IsNullOrEmpty(displaySuffix) ? jobname : $"{jobname} {displaySuffix}";
-                                                var _prejobdisplayname = defJobName(jobname);
-                                                if(callingJob?.Name != null) {
-                                                    _prejobdisplayname = callingJob.Name + " / " + _prejobdisplayname;
-                                                }
+                                                var _prejobdisplayname = defJobName(_jobdisplayname);
                                                 if(jobTotal > 1) {
                                                     next.TimelineId = Guid.NewGuid();
                                                     // For Runner.Client to show the workflowname

--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -1492,7 +1492,7 @@ namespace Runner.Server.Controllers
                                     jobitem.DisplayName = _jobdisplayname;
                                     // For Runner.Client to show the workflowname
                                     initializingJobs.TryAdd(jobitem.Id, new Job() { JobId = jobitem.Id, TimeLineId = jobitem.TimelineId, name = jobitem.DisplayName, workflowname = workflowname, runid = runid, RequestId = jobitem.RequestId } );
-                                    new TimelineController(    , Configuration).UpdateTimeLine(jobitem.TimelineId, new VssJsonCollectionWrapper<List<TimelineRecord>>(TimelineController.dict[jobitem.TimelineId].Item1));
+                                    new TimelineController(_context, Configuration).UpdateTimeLine(jobitem.TimelineId, new VssJsonCollectionWrapper<List<TimelineRecord>>(TimelineController.dict[jobitem.TimelineId].Item1));
                                     jobTraceWriter.Info("{0}", $"Evaluate if");
                                     var ifexpr = (from r in run where r.Key.AssertString($"jobs.{jobname} mapping key").Value == "if" select r).FirstOrDefault().Value;
                                     var translateConditionCtx = CreateTemplateContext(jobTraceWriter, workflowContext.FileTable);

--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -1840,10 +1840,13 @@ namespace Runner.Server.Controllers
                                                     jobitem.Childs?.Add(next);
                                                     TimeLineWebConsoleLogController.AppendTimelineRecordFeed(new TimelineRecordFeedLinesWrapper(next.Id, new List<string>{ $"Evaluate job name" }), next.TimelineId, next.Id);
                                                     var templateContext = CreateTemplateContext(matrixJobTraceWriter, workflowContext.FileTable, contextData);
-                                                    var _jobdisplayname = (from r in run where r.Key.AssertString($"jobs.{jobname} mapping key").Value == "name" select r.Value is StringToken token ? defJobName(token.Value) : GitHub.DistributedTask.ObjectTemplating.TemplateEvaluator.Evaluate(templateContext, "string-strategy-context", r.Value, 0, null, true).AssertString($"jobs.{jobname}.name must be a string").Value).FirstOrDefault() ?? defJobName(jobname);
-                                                    templateContext.Errors.Check();
-                                                    if(callingJob?.Name != null) {
-                                                        _jobdisplayname = callingJob.Name + " / " + _jobdisplayname;
+                                                    var _jobdisplayname = _prejobdisplayname;
+                                                    if(jobNameToken != null && !(jobNameToken is StringToken)) {
+                                                        _jobdisplayname = GitHub.DistributedTask.ObjectTemplating.TemplateEvaluator.Evaluate(templateContext, "string-strategy-context", jobNameToken, 0, null, true).AssertString($"jobs.{jobname}.name must be a string").Value;
+                                                        templateContext.Errors.Check();
+                                                        if(callingJob?.Name != null) {
+                                                            _jobdisplayname = callingJob.Name + " / " + _jobdisplayname;
+                                                        }
                                                     }
                                                     next.DisplayName = _jobdisplayname;
                                                     TimeLineWebConsoleLogController.AppendTimelineRecordFeed(new TimelineRecordFeedLinesWrapper(next.Id, new List<string>{ $"Evaluate job continueOnError" }), next.TimelineId, next.Id);

--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -1483,7 +1483,8 @@ namespace Runner.Server.Controllers
                                     var jobrecord = new TimelineRecord{ Id = jobitem.Id, Name = jobitem.name };
                                     TimelineController.dict[jobitem.TimelineId] = ( new List<TimelineRecord>{ jobrecord }, new System.Collections.Concurrent.ConcurrentDictionary<System.Guid, System.Collections.Generic.List<GitHub.DistributedTask.WebApi.TimelineRecordLogLine>>() );
                                     var jobTraceWriter = new TraceWriter2(line => TimeLineWebConsoleLogController.AppendTimelineRecordFeed(new TimelineRecordFeedLinesWrapper(jobitem.Id, new List<string>{ line }), jobitem.TimelineId, jobitem.Id));
-                                    var _jobdisplayname = (from r in run where r.Key.AssertString($"jobs.{jobname} mapping key").Value == "name" select r.Value.ToString()).FirstOrDefault() ?? jobitem.name;
+                                    var jobNameToken = (from r in run where r.Key.AssertString($"jobs.{jobname} mapping key").Value == "name" select r.Value).FirstOrDefault();
+                                    var _jobdisplayname = jobNameToken is StringToken jobNameStringToken ? jobNameStringToken.ToString() : jobitem.name;
                                     if(callingJob?.Name != null) {
                                         _jobdisplayname = callingJob.Name + " / " + _jobdisplayname;
                                     }
@@ -1491,7 +1492,7 @@ namespace Runner.Server.Controllers
                                     jobitem.DisplayName = _jobdisplayname;
                                     // For Runner.Client to show the workflowname
                                     initializingJobs.TryAdd(jobitem.Id, new Job() { JobId = jobitem.Id, TimeLineId = jobitem.TimelineId, name = jobitem.DisplayName, workflowname = workflowname, runid = runid, RequestId = jobitem.RequestId } );
-                                    new TimelineController(_context, Configuration).UpdateTimeLine(jobitem.TimelineId, new VssJsonCollectionWrapper<List<TimelineRecord>>(TimelineController.dict[jobitem.TimelineId].Item1));
+                                    new TimelineController(    , Configuration).UpdateTimeLine(jobitem.TimelineId, new VssJsonCollectionWrapper<List<TimelineRecord>>(TimelineController.dict[jobitem.TimelineId].Item1));
                                     jobTraceWriter.Info("{0}", $"Evaluate if");
                                     var ifexpr = (from r in run where r.Key.AssertString($"jobs.{jobname} mapping key").Value == "if" select r).FirstOrDefault().Value;
                                     var translateConditionCtx = CreateTemplateContext(jobTraceWriter, workflowContext.FileTable);

--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -1484,7 +1484,7 @@ namespace Runner.Server.Controllers
                                     TimelineController.dict[jobitem.TimelineId] = ( new List<TimelineRecord>{ jobrecord }, new System.Collections.Concurrent.ConcurrentDictionary<System.Guid, System.Collections.Generic.List<GitHub.DistributedTask.WebApi.TimelineRecordLogLine>>() );
                                     var jobTraceWriter = new TraceWriter2(line => TimeLineWebConsoleLogController.AppendTimelineRecordFeed(new TimelineRecordFeedLinesWrapper(jobitem.Id, new List<string>{ line }), jobitem.TimelineId, jobitem.Id));
                                     var jobNameToken = (from r in run where r.Key.AssertString($"jobs.{jobname} mapping key").Value == "name" select r.Value).FirstOrDefault();
-                                    var _jobdisplayname = jobNameToken is StringToken jobNameStringToken ? jobNameStringToken.ToString() : jobitem.name;
+                                    var _jobdisplayname = jobNameToken?.ToString() ?? jobitem.name;
                                     if(callingJob?.Name != null) {
                                         _jobdisplayname = callingJob.Name + " / " + _jobdisplayname;
                                     }


### PR DESCRIPTION
Matrix jobs with a name, but without any expressions also have the default matrix job `( ... )` name suffix.
Ignore empty values while building brackets, e.g. `matrix: { "", true }` , `matrix: { null, true }` =>  `<jobname> (true)` and  `matrix: { null }`, `matrix: { "" }` =>  `<jobname>`