### PR TITLE
Fix crash duplicated environment secrets

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -105,7 +105,7 @@ jobs:
         gharun -W testworkflows/testhashfiles.yml
         gharun -W testworkflows/dumpcontexts.yml
         cd testworkflows/environment-test
-        gharun -W sample.yml --environment-secret-file develop=develop.yml --environment-secret-file staging=staging.yaml --environment-secret-file prod=prod.secrets
+        gharun -W sample.yml --environment-secret-file prod=prod.secrets --environment-secret-file develop=develop.yml --environment-secret-file staging=staging.yaml --environment-secret-file prod=prod.secrets
         cd ../..
         gharun -W testworkflows/dumpcontexts.yml --list
         ${{matrix.image && 'echo "Skipping additional testcases" && exit 0' || ''}}

--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -3773,7 +3773,7 @@ namespace Runner.Server.Controllers
 
             var workflow = (from f in form.Files where f.Name != "event" && !(f.FileName.EndsWith(".secrets") && f.Name == "actions-environment-secrets") select new KeyValuePair<string, string>(f.FileName, new StreamReader(f.OpenReadStream()).ReadToEnd())).ToArray();
             var des = new DeserializerBuilder().Build();
-            var secretsEnvironments = (from f in form.Files where f.FileName.EndsWith(".secrets") && f.Name == "actions-environment-secrets" select (f.FileName.Substring(0, f.FileName.Length - 8), des.Deserialize<IDictionary<string, string>>(new StreamReader(f.OpenReadStream())))).ToDictionary(kv => kv.Item1, kv => (IDictionary<string, string>) new Dictionary<string, string>(kv.Item2, StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
+            var secretsEnvironments = (from f in form.Files where f.FileName.EndsWith(".secrets") && f.Name == "actions-environment-secrets" select (f.FileName.Substring(0, f.FileName.Length - 8), des.Deserialize<IDictionary<string, string>>(new StreamReader(f.OpenReadStream())))).ToOrdinalIgnoreCaseDictionary(kv => kv.Item1, kv => (IDictionary<string, string>) kv.Item2.ToOrdinalIgnoreCaseDictionary());
             if(!secretsEnvironments.ContainsKey("") && secrets?.Length > 0) {
                 var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 LoadEnvSec(secrets, (k, v) => dict[k] = v);

--- a/src/Runner.Server/Extensions.cs
+++ b/src/Runner.Server/Extensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using GitHub.DistributedTask.ObjectTemplating.Tokens;
 
 namespace Runner.Server {
@@ -57,6 +58,22 @@ namespace Runner.Server {
                 default:
                 return token.AssertMapping(objectDescription);
             }
+        }
+
+        public static Dictionary<string, TSource> ToOrdinalIgnoreCaseDictionary<TSource>(this IEnumerable<KeyValuePair<string, TSource>> source) {
+            var ret = new Dictionary<string, TSource>(StringComparer.OrdinalIgnoreCase);
+            foreach(var kv in source) {
+                ret[kv.Key] = kv.Value;
+            }
+            return ret;
+        }
+
+        public static Dictionary<string, TValue> ToOrdinalIgnoreCaseDictionary<TSource, TValue>(this IEnumerable<TSource> source, Func<TSource, string> keySelector, Func<TSource, TValue> valueSelector) {
+            var ret = new Dictionary<string, TValue>(StringComparer.OrdinalIgnoreCase);
+            foreach(var kv in source) {
+                ret[keySelector(kv)] = valueSelector(kv);
+            }
+            return ret;
         }
     }
 }

--- a/testworkflows/environment-test/prod.secrets
+++ b/testworkflows/environment-test/prod.secrets
@@ -1,3 +1,4 @@
+Secret1=This value is replaced later, be the second line
 secret1<<DELIMITER
 My multiline secret
 it's the environment file syntax of github actions

--- a/testworkflows/environment-test/staging.yaml
+++ b/testworkflows/environment-test/staging.yaml
@@ -1,3 +1,6 @@
+Secret1: |
+  This value will be discarded without a crash
+SECRET2: Dummy
 secret1: |
   My multiline secret
   it's yaml


### PR DESCRIPTION
e.g.
```yaml
Test: val1
test: val2
```

Fix crash if you add the same environment name multiple times