### PR TITLE
matrix deepequal use expression eq for scalars

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -108,12 +108,12 @@ jobs:
         gharun -W testworkflows/multiline_env.yml --env-file testworkflows/multiline_secrets.secrets
         gharun -W testworkflows/multiline_secrets.yml --secret-file testworkflows/multiline_secrets.secrets.yaml
         gharun -W testworkflows/multiline_env.yml --env-file testworkflows/multiline_secrets.secrets.yaml
-        gharun -W testworkflows/matrix-eq-test.yml --parallel 2
         cd testworkflows/environment-test
         gharun -W sample.yml --environment-secret-file prod=prod.secrets --environment-secret-file develop=develop.yml --environment-secret-file staging=staging.yaml --environment-secret-file prod=prod.secrets
         cd ../..
         gharun -W testworkflows/dumpcontexts.yml --list
         gharun -C testworkflows/case-insensitive-keys-matrix
+        gharun -C testworkflows/matrix-eq-test --parallel 2
         ${{matrix.image && 'echo "Skipping additional testcases" && exit 0' || ''}}
         gharun -W testworkflows/cache.yml -P ubuntu-latest=-self-hosted
         gharun -P ubuntu-latest=-self-hosted -W testworkflows/matrixtest.yml --parallel 1

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -108,6 +108,7 @@ jobs:
         gharun -W testworkflows/multiline_env.yml --env-file testworkflows/multiline_secrets.secrets
         gharun -W testworkflows/multiline_secrets.yml --secret-file testworkflows/multiline_secrets.secrets.yaml
         gharun -W testworkflows/multiline_env.yml --env-file testworkflows/multiline_secrets.secrets.yaml
+        gharun -W testworkflows/matrix-eq-test.yml --parallel 2
         cd testworkflows/environment-test
         gharun -W sample.yml --environment-secret-file prod=prod.secrets --environment-secret-file develop=develop.yml --environment-secret-file staging=staging.yaml --environment-secret-file prod=prod.secrets
         cd ../..

--- a/testworkflows/matrix-eq-test/.github/workflows/matrix-eq-test.yml
+++ b/testworkflows/matrix-eq-test/.github/workflows/matrix-eq-test.yml
@@ -1,0 +1,41 @@
+on: push
+jobs:
+  _0:
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        a:
+        - a # excluded by A
+        - b
+        - 0 # excluded by null
+        - '' # excluded by null
+        - null # excluded by null
+        - false # excluded by null
+        exclude:
+        - A: A
+        - A: null
+    steps:
+    - run: echo "'${{ matrix.A }}' = 'b'"
+    - run: exit ${{ matrix.A == 'B' && '0' || '1' }}
+  _1:
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        a:
+        - b
+        - # excluded by complex object with mismatched case and abstract equality
+          a0: a 
+          a1: 0
+          a2: ''
+          a3: null
+          4: false
+        exclude:
+        - A:
+            A0: A 
+            A1: 0
+            A2: 0
+            A3: 0
+            4: 0
+    steps:
+    - run: echo "'${{ matrix.A }}' = 'b'"
+    - run: exit ${{ matrix.A == 'B' && '0' || '1' }}


### PR DESCRIPTION
It is interesting how complex github-actions behavior is, since only a small subset is documented. I didn't know this behavior until recently.

```yaml
on: push
jobs:
  _:
    runs-on: self-hosted
    strategy:
      matrix:
        a:
        - a # excluded by A
        - b
        - '' # excluded by null
        - null # excluded by null
        exclude:
        - A: A
        - A: null
     steps:
     - run: echo "'${{ matrix.A }}' = 'b'"
```