### PR TITLE
Allow inputs context in more places

### DIFF
--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -125,7 +125,8 @@
     "job-with-entry": {
       "context": [
         "github",
-        "needs"
+        "needs",
+        "inputs"
       ],
       "one-of": [
         "boolean",
@@ -152,6 +153,7 @@
       "context": [
         "github",
         "needs",
+        "inputs",
         "secrets"
       ],
       "string": {}


### PR DESCRIPTION
 jobs.*.with.* and jobs.*.secrets.* can now use inputs context for workflow_dispatch

_Using them on github seems to be buggy as of today, because it is assigned to null for workflow_dispatch_