### PR TITLE
Optionally handle invalid actions if syntax

### DIFF
--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -940,6 +940,12 @@ namespace Runner.Server.Controllers
             if(context.HasFeature("system.runner.server.allowAnyForInsert")) {
                 flags |= ExpressionFlags.AllowAnyForInsert;
             }
+            if(context.HasFeature("system.runner.server.FixInvalidActionsIfExpression")) {
+                flags |= ExpressionFlags.FixInvalidActionsIfExpression;
+            }
+            if(context.HasFeature("system.runner.server.FailInvalidActionsIfExpression")) {
+                flags |= ExpressionFlags.FailInvalidActionsIfExpression;
+            }
             var templateContext = new TemplateContext() {
                 Flags = flags,
                 CancellationToken = CancellationToken.None,

--- a/src/Runner.Worker/ActionManifestManager.cs
+++ b/src/Runner.Worker/ActionManifestManager.cs
@@ -325,6 +325,12 @@ namespace GitHub.Runner.Worker
             if(executionContext.Global.Variables.GetBoolean("system.runner.server.allowAnyForInsert") == true) {
                 flags |= ExpressionFlags.AllowAnyForInsert;
             }
+            if(executionContext.Global.Variables.GetBoolean("system.runner.server.FixInvalidActionsIfExpression") == true) {
+                flags |= ExpressionFlags.FixInvalidActionsIfExpression;
+            }
+            if(executionContext.Global.Variables.GetBoolean("system.runner.server.FailInvalidActionsIfExpression") == true) {
+                flags |= ExpressionFlags.FailInvalidActionsIfExpression;
+            }
             var result = new TemplateContext
             {
                 Flags = flags,

--- a/src/Runner.Worker/action_yaml.json
+++ b/src/Runner.Worker/action_yaml.json
@@ -250,6 +250,7 @@
               "success(0,0)",
               "hashFiles(1,255)"
             ],
+            "actionsIfExpression": true,
             "string": {}
         },
         "step-with": {

--- a/src/Sdk/DTExpressions2/Expressions2/ExpressionParser.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/ExpressionParser.cs
@@ -18,6 +18,8 @@ namespace GitHub.DistributedTask.Expressions2
         ExtendedDirectives = 4,
         ExtendedFunctions = 8,
         AllowAnyForInsert = 16,
+        FailInvalidActionsIfExpression = 32,
+        FixInvalidActionsIfExpression = 64,
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/Schema/Definition.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/Schema/Definition.cs
@@ -49,12 +49,20 @@ namespace GitHub.DistributedTask.ObjectTemplating.Schema
                 {
                     definition.RemoveAt(i);
                 }
+                else if (String.Equals(definitionKey.Value, "actionsIfExpression", StringComparison.Ordinal))
+                {
+                    var actionifexpr = definition[i].Value.AssertBoolean($"actionsIfExpression");
+                    definition.RemoveAt(i);
+                    ActionsIfExpression = actionifexpr.Value;
+                }
                 else
                 {
                     i++;
                 }
             }
         }
+
+        public bool ActionsIfExpression { get; private set; }
 
         internal abstract DefinitionType DefinitionType { get; }
 

--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/Schema/TemplateSchema.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/Schema/TemplateSchema.cs
@@ -108,6 +108,7 @@ namespace GitHub.DistributedTask.ObjectTemplating.Schema
 
                                         case TemplateConstants.Context:
                                         case TemplateConstants.Description:
+                                        case "actionsIfExpression":
                                             continue;
 
                                         default:
@@ -371,6 +372,7 @@ namespace GitHub.DistributedTask.ObjectTemplating.Schema
                     mappingDefinition.Properties.Add(TemplateConstants.Description, new PropertyValue(new StringToken(null, null, null, TemplateConstants.String)));
                     mappingDefinition.Properties.Add(TemplateConstants.Context, new PropertyValue(new StringToken(null, null, null, TemplateConstants.SequenceOfNonEmptyString)));
                     mappingDefinition.Properties.Add(TemplateConstants.String, new PropertyValue(new StringToken(null, null, null, TemplateConstants.StringDefinitionProperties)));
+                    mappingDefinition.Properties.Add("actionsIfExpression", new PropertyValue(new StringToken(null, null, null, TemplateConstants.Boolean)));
                     schema.Definitions.Add(TemplateConstants.StringDefinition, mappingDefinition);
 
                     // string-definition-properties

--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -186,6 +186,7 @@
         "cancelled(0,0)",
         "success(0,MAX)"
       ],
+      "actionsIfExpression": true,
       "string": {}
     },
 
@@ -470,6 +471,7 @@
         "success(0,0)",
         "hashFiles(1,255)"
       ],
+      "actionsIfExpression": true,
       "string": {}
     },
 


### PR DESCRIPTION
This change allows to either ignore, fail or fix the expression

This is considered as an invalid if expression
```yaml
if: ${{ inputs.key }} == 'test'
```

- `--var system.runner.server.FailInvalidActionsIfExpression=true` will throw an error before it actually executes the partially invald workflow
- `--var system.runner.server.FixInvalidActionsIfExpression=true` will fix the if expression and translates it to `${{ inputs.key == 'test' }}`