### PR TITLE
azp: Add missing functionality

### DIFF
--- a/src/Runner.Server/Controllers/CounterFunction.cs
+++ b/src/Runner.Server/Controllers/CounterFunction.cs
@@ -1,0 +1,20 @@
+using System;
+using GitHub.DistributedTask.Expressions2.Sdk;
+using GitHub.DistributedTask.Expressions2.Sdk.Functions.v1;
+
+namespace Runner.Server.Controllers
+{
+    public class CounterFunction : Function
+    {
+        protected override object EvaluateCore(EvaluationContext context, out ResultMemory memory)
+        {
+            memory = null;
+            String left = Parameters[0].EvaluateString(context) as String ?? String.Empty;
+            if(Parameters.Count == 2) {
+                var seed = Parameters[1].Evaluate(context).ConvertToNumber();
+                return seed;
+            }
+            return 0;
+        }
+    }
+}

--- a/src/Runner.Server/Controllers/PipelineContext.cs
+++ b/src/Runner.Server/Controllers/PipelineContext.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using GitHub.DistributedTask.Expressions2.Sdk;
+using Runner.Server.Azure.Devops;
+
+namespace Runner.Server.Controllers
+{
+    internal class PipelineContext : IReadOnlyObject
+    {
+        private Dictionary<string, object> data;
+        public PipelineContext(DateTime starttime)
+        {
+            data = new(StringComparer.OrdinalIgnoreCase);
+            data["startTime"] = new DateTimeWrapper { DateTime = starttime };
+        }
+
+        public object this[string key] => data[key];
+
+        public int Count => data.Count;
+
+        public IEnumerable<string> Keys => data.Keys;
+
+        public IEnumerable<object> Values => data.Values;
+
+        public bool ContainsKey(string key)
+        {
+            return data.ContainsKey(key);
+        }
+
+        public IEnumerator GetEnumerator()
+        {
+            return data.GetEnumerator();
+        }
+
+        public bool TryGetValue(string key, out object value)
+        {
+            return data.TryGetValue(key, out value);
+        }
+    }
+}

--- a/src/Sdk/AzurePipelines/DateTimeWrapper.cs
+++ b/src/Sdk/AzurePipelines/DateTimeWrapper.cs
@@ -1,0 +1,13 @@
+using System;
+using GitHub.DistributedTask.Expressions2.Sdk;
+
+namespace Runner.Server.Azure.Devops {
+    public class DateTimeWrapper : IString {
+        public DateTime DateTime { get; set; }
+        
+        public String GetString() {
+            // 2022-11-20 15:38:45+00:00
+            return DateTime.ToString("yyyy-MM-dd HH:mm:ssK");
+        }
+    }
+}

--- a/src/Sdk/AzurePipelines/azurepiplines.json
+++ b/src/Sdk/AzurePipelines/azurepiplines.json
@@ -36,7 +36,10 @@
       "context": [
         "variables",
         "dependencies",
-        "stageDependencies"
+        "stageDependencies",
+        "pipeline",
+        "resources",
+        "Counter(0,2)"
       ],
       "string": {}
     },

--- a/src/Sdk/DTExpressions2/Expressions2/Sdk/Functions/Format.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/Sdk/Functions/Format.cs
@@ -254,6 +254,10 @@ namespace GitHub.DistributedTask.Expressions2.Sdk.Functions
                     {
                         result = argValue.StringResult;
                     }
+                    else if(argValue.EvaluationResult.Raw is Runner.Server.Azure.Devops.DateTimeWrapper dt)
+                    {
+                        result = dt.DateTime.ToString(formatSpecifiers);
+                    }
                     // Invalid
                     else
                     {


### PR DESCRIPTION
This adds
- `pipeline` context for variable runtime expressions
- `resources` context for variable runtime expressions
- evaluate pipeline name
- evaluate pool, vmimage
- make job variables available for pool, vmimage
- Format DateTime with format function
- stub `counter` for variables, this always returns the initial value or 0.
- parse json results of container expressions