### PR TITLE
azp: restrict expressions usage

### DIFF
--- a/src/Sdk/AzurePipelines/Job.cs
+++ b/src/Sdk/AzurePipelines/Job.cs
@@ -178,7 +178,7 @@ public class Job {
             if(job is MappingToken mstep && mstep.Count > 0) {
                 if((mstep[0].Key as StringToken)?.Value == "template") {
                     var path = (mstep[0].Value as StringToken)?.Value;
-                    var file = AzureDevops.ReadTemplate(context, path, mstep.Count == 2 ? mstep[1].Value.AssertMapping("param").ToDictionary(kv => kv.Key.AssertString("").Value, kv => kv.Value) : null);
+                    var file = AzureDevops.ReadTemplate(context, path, mstep.Count == 2 ? mstep[1].Value.AssertMapping("param").ToDictionary(kv => kv.Key.AssertString("").Value, kv => kv.Value) : null, "job-template-root");
                     ParseJobs(context.ChildContext(file, path), jobs, (from e in file where e.Key.AssertString("").Value == "jobs" select e.Value).First().AssertSequence(""));
                 } else {
                     jobs.Add(new Job().Parse(context, mstep));

--- a/src/Sdk/AzurePipelines/Stage.cs
+++ b/src/Sdk/AzurePipelines/Stage.cs
@@ -59,7 +59,7 @@ public class Stage {
             if(job is MappingToken mstep && mstep.Count > 0) {
                 if((mstep[0].Key as StringToken)?.Value == "template") {
                     var path = (mstep[0].Value as StringToken)?.Value;
-                    var file = AzureDevops.ReadTemplate(context, path, mstep.Count == 2 ? mstep[1].Value.AssertMapping("param").ToDictionary(kv => kv.Key.AssertString("").Value, kv => kv.Value) : null);
+                    var file = AzureDevops.ReadTemplate(context, path, mstep.Count == 2 ? mstep[1].Value.AssertMapping("param").ToDictionary(kv => kv.Key.AssertString("").Value, kv => kv.Value) : null, "stage-template-root");
                     ParseStages(context.ChildContext(file, path), stages, (from e in file where e.Key.AssertString("").Value == "stages" select e.Value).First().AssertSequence(""));
                 } else {
                     stages.Add(new Stage().Parse(context, mstep));

--- a/src/Sdk/AzurePipelines/azurepiplines.json
+++ b/src/Sdk/AzurePipelines/azurepiplines.json
@@ -85,9 +85,22 @@
       "mapping": {
         "properties": {
           "containers": "pipeline-containers",
-          "repositories": "pipeline-repositories"
+          "repositories": "pipeline-repositories",
+          "pipelines": "any",
+          "builds": "any",
+          "packages": "any"
         }
       }
+    },
+
+    "pipeline-root": {
+      "description": "Pipeline file",
+      "one-of": [
+        "extends-pipeline-root",
+        "stage-pipeline-root",
+        "job-pipeline-root",
+        "steps-pipeline-root"
+      ]
     },
 
     "extends-pipeline-root": {
@@ -215,6 +228,19 @@
         "properties": {
           "parameters": "any",
           "steps": {
+            "type": "workflow-value",
+            "required": true
+          }
+        }
+      }
+    },
+
+    "variable-template-root": {
+      "description": "Variable Template file",
+      "mapping": {
+        "properties": {
+          "parameters": "any",
+          "variables": {
             "type": "workflow-value",
             "required": true
           }


### PR DESCRIPTION
Before this change you could use expressions everywhere outside of the parameters key.