### PR TITLE
azp: fix null exception on access to system.jobid

### DIFF
--- a/src/Runner.Client/ExternalToolHelper.cs
+++ b/src/Runner.Client/ExternalToolHelper.cs
@@ -172,6 +172,7 @@ namespace Runner.Client
                         { "linux/arm", dest => DownloadTool(AURL("linux-arm", "tar.gz"), dest, token, unwrap: false)},
                         { "linux/arm64", dest => DownloadTool(AURL("linux-arm64", "tar.gz"), dest, token, unwrap: false)},
                         { "osx/amd64", dest => DownloadTool(AURL("osx-x64", "tar.gz"), dest, token, unwrap: false)},
+                        { "osx/arm64", dest => DownloadTool(AURL("osx-arm64", "tar.gz"), dest, token, unwrap: false)},
                     };
                 } else {
                     Func<string, string, string> AURL = (arch, ext) => $"https://github.com/actions/runner/releases/download/v{version}/actions-runner-{arch}-{version}.{ext}";

--- a/src/Runner.Client/Program.cs
+++ b/src/Runner.Client/Program.cs
@@ -1075,7 +1075,7 @@ namespace Runner.Client
                 if(parameters.Parallel > 0) {
                     var azure = string.Equals(parameters.Event, "azpipelines", StringComparison.OrdinalIgnoreCase);
                     if(string.IsNullOrEmpty(parameters.RunnerVersion) && string.IsNullOrEmpty(parameters.RunnerPath) && azure) {
-                        parameters.RunnerVersion = "2.210.0";
+                        parameters.RunnerVersion = "2.213.2";
                     }
                     if(!string.IsNullOrEmpty(parameters.RunnerVersion)) {
                         parameters.RunnerPath = Directory.GetParent(await ExternalToolHelper.GetAgent(azure ? "azagent" : "runner", parameters.RunnerVersion, source.Token)).Parent.FullName;

--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -3692,6 +3692,7 @@ namespace Runner.Server.Controllers
                                     // If this is not a non zero guid upload artifact tasks refuse to work
                                     variables["system.teamProjectId"] = new VariableValue("667b63ea-5b23-4619-9431-f2cff4e16a11", false);
                                     variables["System.DefinitionId"] = new VariableValue(Guid.Empty.ToString(), false);
+                                    variables["System.planid"] = new VariableValue(Guid.Empty.ToString(), false);
                                     variables["system.definitionName"] = new VariableValue(Guid.Empty.ToString(), false);
                                     variables["Build.Clean"] = new VariableValue("true", false);
                                     variables["Build.SyncSources"] = new VariableValue("true", false);
@@ -5716,9 +5717,11 @@ namespace Runner.Server.Controllers
                             svariables[secr.Key] = new VariableValue(secr.Value, true);
                         }
                         svariables[SdkConstants.Variables.Build.ContainerId] = fileContainerId.ToString();
-                        svariables["system.collectionUri"] = new VariableValue(apiUrl, false);
-                        svariables["system.teamFoundationCollectionUri"] = new VariableValue(apiUrl, false);
-                        svariables["system.taskDefinitionsUri"] = new VariableValue(apiUrl, false);
+                        svariables["system.collectionUri"] = new VariableValue(apiUrl, false, true);
+                        svariables["system.teamFoundationCollectionUri"] = new VariableValue(apiUrl, false, true);
+                        svariables["system.taskDefinitionsUri"] = new VariableValue(apiUrl, false, true);
+                        svariables["system.jobid"] = new VariableValue(jobId.ToString(), false, true);
+                        svariables["system.timelineid"] = new VariableValue(timelineId.ToString(), false, true);
 
                         var tokenHandler = new JwtSecurityTokenHandler();
                         var tokenDescriptor = new SecurityTokenDescriptor


### PR DESCRIPTION
This fixes 2.213.0 agents due to missing default agent variables, also bumped the default azure agent to 2.213.2.

osx-arm64 release, should now download on m1 macs via a 3.x.x `--runner-version`.