### PR TITLE
fix github.workflow in reusable workflows

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -101,6 +101,7 @@ jobs:
         echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
     - name: Test
       run: |
+        set -x
         gharun -W testworkflows/testlocalcheckout.yml
         gharun -W testworkflows/testhashfiles.yml
         gharun -W testworkflows/dumpcontexts.yml
@@ -148,6 +149,7 @@ jobs:
         gharun -C testworkflows/workflow_dispatch workflow_dispatch -i Misc=myInput -i SI=UdHe -i bVal=true -i BVAL2=false
         gharun -C testworkflows/matrix-selector push -j test -m fail:false
         gharun -C testworkflows/oidc-provider
+        gharun -C testworkflows/reusablesConsistentWorkflowName
         gharun --event azpipelines -C testworkflows/azpipelines/cross-repo-checkout -W testworkflows/azpipelines/cross-repo-checkout/pipeline.yml --local-repository az/containermatrix@main=testworkflows/azpipelines/containermatrix
         gharun --event azpipelines -C testworkflows/azpipelines/typedtemplates -W testworkflows/azpipelines/typedtemplates/pipeline.yml
         gharun --event azpipelines -C testworkflows/azpipelines/untypedtemplates -W testworkflows/azpipelines/untypedtemplates/pipeline.yml

--- a/testworkflows/reusablesConsistentWorkflowName/.github/workflows/main-custom-name-run-name.yml
+++ b/testworkflows/reusablesConsistentWorkflowName/.github/workflows/main-custom-name-run-name.yml
@@ -1,0 +1,16 @@
+name: custom-name
+run-name: ${{ github.workflow }}-${{ github.event_name }}
+on:
+  push:
+jobs:
+  pre:
+    runs-on: {}
+    steps:
+    - run: exit ${{ github.workflow == 'custom-name' && '0' || '1' }}
+    outputs:
+      workflowName: ${{ github.workflow }}
+  main:
+    needs: pre
+    uses: ./.github/workflows/reusable.yml
+    with:
+      workflowName: ${{ needs.pre.outputs.workflowName }}

--- a/testworkflows/reusablesConsistentWorkflowName/.github/workflows/main-custom-name.yml
+++ b/testworkflows/reusablesConsistentWorkflowName/.github/workflows/main-custom-name.yml
@@ -1,0 +1,15 @@
+name: custom-name
+on:
+  push:
+jobs:
+  pre:
+    runs-on: {}
+    steps:
+    - run: exit ${{ github.workflow == 'custom-name' && '0' || '1' }}
+    outputs:
+      workflowName: ${{ github.workflow }}
+  main:
+    needs: pre
+    uses: ./.github/workflows/reusable.yml
+    with:
+      workflowName: ${{ needs.pre.outputs.workflowName }}

--- a/testworkflows/reusablesConsistentWorkflowName/.github/workflows/main.yml
+++ b/testworkflows/reusablesConsistentWorkflowName/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+jobs:
+  pre:
+    runs-on: {}
+    steps:
+    - run: exit ${{ github.workflow == '.github/workflows/main.yml' && '0' || '1' }}
+    outputs:
+      workflowName: ${{ github.workflow }}
+  main:
+    needs: pre
+    uses: ./.github/workflows/reusable.yml
+    with:
+      workflowName: ${{ needs.pre.outputs.workflowName }}

--- a/testworkflows/reusablesConsistentWorkflowName/.github/workflows/reusable.yml
+++ b/testworkflows/reusablesConsistentWorkflowName/.github/workflows/reusable.yml
@@ -1,0 +1,11 @@
+on:
+  workflow_call:
+    inputs:
+      workflowName:
+        type: string
+jobs:
+  test:
+    runs-on: {}
+    steps:
+    - run: exit ${{ inputs.workflowName != github.workflow && '1' || '0' }}
+    - run: exit ${{ github.event_name != 'push' && '1' || '0' }}


### PR DESCRIPTION
The github.workflow field have had the wrong value in reusable workflows, since 3.11.0.
This change adds a test to prevent another regression.

run-name no longer overrides workflowname.