### PR TITLE
Allow matrix context in job outputs

### DIFF
--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -326,6 +326,9 @@
     },
 
     "job-outputs": {
+      "context": [
+        "matrix"
+      ],
       "mapping": {
         "loose-key-type": "non-empty-string",
         "loose-value-type": "string-runner-context"


### PR DESCRIPTION
Synchronize context availability

Based on https://github.com/actions/runner/pull/2477