### PR TITLE
azp: allow missing steps and jobs fields

### DIFF
--- a/src/Sdk/AzurePipelines/Job.cs
+++ b/src/Sdk/AzurePipelines/Job.cs
@@ -271,11 +271,14 @@ public class Job {
             job["variables"] = vars;
         }
         if(!DeploymentJob) {
-            var steps = new ArrayContextData();
-            foreach(var step in Steps) {
-                steps.Add(step.ToContextData());
+            // Azure Pipelines seem to ignore missing steps as long as it is only template parameter
+            if(Steps != null) {
+                var steps = new ArrayContextData();
+                foreach(var step in Steps) {
+                    steps.Add(step.ToContextData());
+                }
+                job["steps"] = steps;
             }
-            job["steps"] = steps;
         } else {
             if(EnvironmentName != null) {
                 if(EnvironmentResourceType != null) {

--- a/src/Sdk/AzurePipelines/Stage.cs
+++ b/src/Sdk/AzurePipelines/Stage.cs
@@ -111,11 +111,14 @@ public class Stage {
             }
             stage["variables"] = vars;
         }
-        var jobs = new ArrayContextData();
-        foreach(var job in Jobs) {
-            jobs.Add(job.ToContextData());
+        // Azure Pipelines seem to ignore missing jobs as long as it is only template parameter
+        if(Jobs != null) {
+            var jobs = new ArrayContextData();
+            foreach(var job in Jobs) {
+                jobs.Add(job.ToContextData());
+            }
+            stage["jobs"] = jobs;
         }
-        stage["jobs"] = jobs;
         if(Pool != null) {
             stage["pool"] = Pool.ToContextData();
         }


### PR DESCRIPTION
In template parameters is Azure Pipelines less restrictive, so don't throw nullpointer errors in this case