### PR TITLE
dotnet 8.0 runtime fix

### DIFF
--- a/src/Runner.Server/Startup.cs
+++ b/src/Runner.Server/Startup.cs
@@ -86,6 +86,7 @@ namespace Runner.Server
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddHttpLogging(logging => {}); // dotnet 8.0 breaking See https://github.com/dotnet/aspnetcore/issues/51322
             services.TryAddSingleton<IPolicyEvaluator, AgentAuthenticationPolicyEvaluator>();
 
             services.AddControllers(options => {


### PR DESCRIPTION
Based on this issue report (https://github.com/dotnet/aspnetcore/issues/51322), it is now important to call `AddHttpLogging`.

This function does exists for a while in aspnet and in .net6, nuget and fxdependent packages did fail while running on .net8.0 via rollforward.