### PR TITLE
azp-ext: suppress required var prompt during normal editing

### DIFF
--- a/src/Sdk.Tests/AzurePipelines/AzurePipelinesUtilsTests.cs
+++ b/src/Sdk.Tests/AzurePipelines/AzurePipelinesUtilsTests.cs
@@ -1,0 +1,10 @@
+namespace Runner.Server.Azure.Devops
+{
+    public class AzurePipelinesUtilsTests {
+        [Fact]
+        public void TestYAMLToJson() {
+            string json = AzurePipelinesUtils.YAMLToJson("test");
+            Assert.Equal("\"test\"", json);
+        }
+    }
+}

--- a/src/Sdk/AzurePipelines/AzurePipelinesUtils.cs
+++ b/src/Sdk/AzurePipelines/AzurePipelinesUtils.cs
@@ -3,6 +3,7 @@ using System.IO;
 using GitHub.DistributedTask.ObjectTemplating;
 using GitHub.DistributedTask.ObjectTemplating.Tokens;
 using GitHub.DistributedTask.Pipelines.ObjectTemplating;
+using GitHub.DistributedTask.Pipelines.ContextData;
 
 namespace Runner.Server.Azure.Devops {
 
@@ -19,6 +20,9 @@ namespace Runner.Server.Azure.Devops {
                 templateContext.Errors.Check();
                 return ret;
             }
+        }
+        public static string YAMLToJson(string content) {
+            return Newtonsoft.Json.JsonConvert.SerializeObject(ConvertStringToTemplateToken(content).ToContextData().ToJToken());
         }
     }
 }

--- a/src/azure-pipelines-vscode-ext/README.md
+++ b/src/azure-pipelines-vscode-ext/README.md
@@ -233,6 +233,11 @@ npm run build
 
 - Run vscode target "Run azure-pipelines-vscode-ext Extension" to test it
 
+### Nightly VSIX File
+- https://christopherhx.github.io/runner.server/azure-pipelines-vscode-ext/azure-pipelines-vscode-ext.vsix
+- https://christopherhx.github.io/runner.server/azure-pipelines-vscode-ext/azure-pipelines-vscode-ext-pre-release.vsix
+  - same as first one, but marked as pre-release if you install it
+
 ## Changelog
 
 ### v0.0.11

--- a/src/azure-pipelines-vscode-ext/ext-core/Program.cs
+++ b/src/azure-pipelines-vscode-ext/ext-core/Program.cs
@@ -1,5 +1,6 @@
 using GitHub.DistributedTask.ObjectTemplating;
 using GitHub.DistributedTask.ObjectTemplating.Tokens;
+using GitHub.DistributedTask.Pipelines.ContextData;
 using Runner.Server.Azure.Devops;
 using Newtonsoft.Json;
 using System;
@@ -122,4 +123,14 @@ public class MyClass {
             return yaml;
         }
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static string YAMLToJson(string content) {
+        try {
+            return AzurePipelinesUtils.YAMLToJson(content);
+        } catch {
+            return null;
+        }
+    }
+
 }

--- a/src/azure-pipelines-vscode-ext/package-lock.json
+++ b/src/azure-pipelines-vscode-ext/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "azure-pipelines-vscode-ext",
-	"version": "0.0.6",
+	"version": "0.0.13",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "azure-pipelines-vscode-ext",
-			"version": "0.0.5",
+			"version": "0.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"@vscode/debugadapter": "^1.64.0",

--- a/src/azure-pipelines-vscode-ext/package.json
+++ b/src/azure-pipelines-vscode-ext/package.json
@@ -8,7 +8,7 @@
 		"Programming Languages"
 	],
 	"icon": "pipeline-rocket.png",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"publisher": "christopherhx",
 	"repository": "https://github.com/ChristopherHX/runner.server",
 	"engines": {


### PR DESCRIPTION
* Now caches the entered data until you restart the Task
* Only prompt for input on initial start of the Task