### PR TITLE
azp: backward compat fixes of undeclared parameters

### DIFF
--- a/testworkflows/azpipelines/old-style-template-mapping-parameter-declared/pipeline.yml
+++ b/testworkflows/azpipelines/old-style-template-mapping-parameter-declared/pipeline.yml
@@ -1,0 +1,5 @@
+steps:
+- template: ./test.yml
+  parameters:
+    test:
+      script: echo Test

--- a/testworkflows/azpipelines/old-style-template-mapping-parameter-declared/test.yml
+++ b/testworkflows/azpipelines/old-style-template-mapping-parameter-declared/test.yml
@@ -1,0 +1,4 @@
+parameters:
+  test:
+steps:
+- ${{ parameters.test }}

--- a/testworkflows/azpipelines/old-style-template-mapping-parameter-use-undeclared/pipeline.yml
+++ b/testworkflows/azpipelines/old-style-template-mapping-parameter-use-undeclared/pipeline.yml
@@ -1,0 +1,7 @@
+steps:
+- template: ./test.yml
+  parameters:
+    test:
+      script: echo Test
+    test2:
+      script: echo Test

--- a/testworkflows/azpipelines/old-style-template-mapping-parameter-use-undeclared/test.yml
+++ b/testworkflows/azpipelines/old-style-template-mapping-parameter-use-undeclared/test.yml
@@ -1,0 +1,4 @@
+parameters:
+  test:
+steps:
+- ${{ parameters.test2 }}

--- a/testworkflows/azpipelines/old-style-template-no-parameter-declared/pipeline.yml
+++ b/testworkflows/azpipelines/old-style-template-no-parameter-declared/pipeline.yml
@@ -1,0 +1,5 @@
+steps:
+- template: ./test.yml
+  parameters:
+    test:
+      script: echo Test

--- a/testworkflows/azpipelines/old-style-template-no-parameter-declared/test.yml
+++ b/testworkflows/azpipelines/old-style-template-no-parameter-declared/test.yml
@@ -1,0 +1,2 @@
+steps:
+- ${{ parameters.test }}


### PR DESCRIPTION
Repos like the dotnet are using old syntax and don't define all parameters they wire through the templates.

As the pipline is runnable on Azure Pipelines, we should accept it