### PR TITLE
fix: add ac claim for old docker/build-push-action@v3 and make buildx gha cache work

### DIFF
--- a/src/Runner.Server/Controllers/CacheController.cs
+++ b/src/Runner.Server/Controllers/CacheController.cs
@@ -74,7 +74,7 @@ namespace Runner.Server.Controllers {
                     }
                 }
                 CacheRecord partialMatch = null;
-                foreach (var item in a.Skip(1)) {
+                foreach (var item in a) {
                     var record = (from rec in _context.Caches where rec.Repo.ToLower() == repository.ToLower() && rec.Ref == cref && rec.Key.ToLower().StartsWith(item.ToLower()) && (rec.Version == null || rec.Version == "" || rec.Version == version) orderby rec.LastUpdated descending select rec).FirstOrDefault();
                     if(record != null && (partialMatch == null || record.LastUpdated > partialMatch.LastUpdated)) {
                         partialMatch = record;

--- a/src/Runner.Server/Controllers/MessageController.cs
+++ b/src/Runner.Server/Controllers/MessageController.cs
@@ -5713,7 +5713,7 @@ namespace Runner.Server.Controllers
                                 new Claim("runid", runid.ToString()),
                                 new Claim("github_token", variables.TryGetValue("github_token", out var ghtoken) ? ghtoken.Value : ""),
                                 new Claim("scp", $"Actions.Results:{runid}:{job.JobId}"),
-                                new Claim("ac", $"[]")
+                                new Claim("ac", "[{\"Scope\": \"\", \"Permission\": 3}]")
                             }),
                             Expires = DateTime.UtcNow.AddMinutes(timeoutMinutes + 10),
                             Issuer = myIssuer,


### PR DESCRIPTION
Also resolves a warning for current releases

```
| ##[group]GitHub Actions runtime token ACs
| ##[warning]Cannot parse GitHub Actions Runtime Token ACs: "undefined" is not valid JSON
| ##[endgroup]
====>
| ##[group]GitHub Actions runtime token ACs
| ##[endgroup]
```

also cache now works if run via `--interactive` or enabling sqlite persistence
```yaml
on:
  push:
  
jobs:
  docker:
    runs-on: self-hosted
    permissions:
      contents: read
      packages: write
    steps:
    - uses: actions/checkout@v3
    -
      name: Set up QEMU
      uses: docker/setup-qemu-action@v2
    -
      name: Set up Docker Buildx
      uses: docker/setup-buildx-action@v2
    -
    - run: |
        echo "LOWNER<<EOF23" >> $GITHUB_ENV
        echo $(echo "$OWNER" | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
        echo "EOF23" >> $GITHUB_ENV        
      shell: bash
      env:
        OWNER: ${{github.repository_owner}}
    -
      name: Build and push
      uses: docker/build-push-action@v5
      with:
        context: .
        file: Dockerfile
        platforms: linux/amd64
        load: true
        cache-from: type=gha
        cache-to: type=gha,mode=max
        tags: test:test
```