### PR TITLE
fix: accept null content-type

### DIFF
--- a/src/Runner.Server/Extensions.cs
+++ b/src/Runner.Server/Extensions.cs
@@ -118,7 +118,7 @@ namespace Runner.Server
     {
         public async Task BindModelAsync(ModelBindingContext bindingContext)
         {
-            if (!bindingContext.HttpContext.Request.HasJsonContentType())
+            if (bindingContext.HttpContext.Request.ContentType != null && !bindingContext.HttpContext.Request.HasJsonContentType())
             {
                 throw new BadHttpRequestException(
                     "Request content type was not a recognized JSON content type.",


### PR DESCRIPTION
my github-act-runner project doesn't seem to sent the json header during registration and GitHub Actions doesn't care, we shouldn't care either