### PR TITLE
azp: add correct string representation of expr results

### DIFF
--- a/src/Sdk/DTExpressions2/Expressions2/Tokens/LexicalAnalyzer.cs
+++ b/src/Sdk/DTExpressions2/Expressions2/Tokens/LexicalAnalyzer.cs
@@ -143,15 +143,28 @@ namespace GitHub.DistributedTask.Expressions2.Tokens
 
             var length = m_index - startIndex;
             var str = m_expression.Substring(startIndex, length);
-            // Azure Pipelines supports version literals
-            if(periods >= 2 && (Flags & ExpressionFlags.DTExpressionsV1) == ExpressionFlags.DTExpressionsV1) {
-                Version version;
-                if (Version.TryParse(str, out version))
-                {
-                    return new Token(TokenKind.String, str, startIndex, new Runner.Server.Azure.Devops.VersionWrapper { Version = version });
+            if((Flags & ExpressionFlags.DTExpressionsV1) == ExpressionFlags.DTExpressionsV1)
+            {
+                // Azure Pipelines supports version literals
+                if(periods >= 2) {
+                    Version version;
+                    if (Version.TryParse(str, out version))
+                    {
+                        return new Token(TokenKind.String, str, startIndex, new Runner.Server.Azure.Devops.VersionWrapper { Version = version });
+                    }
                 }
-            }
 
+                Decimal dec;
+                if (Decimal.TryParse(
+                        str,
+                        NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign,
+                        CultureInfo.InvariantCulture,
+                        out dec))
+                {
+                    return CreateToken(TokenKind.Number, str, startIndex, (double)dec);
+                }
+                return CreateToken(TokenKind.Unexpected, str, startIndex);
+            }
             var d = ExpressionUtility.ParseNumber(str);
 
             if (Double.IsNaN(d))

--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/Tokens/TemplateToken.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/Tokens/TemplateToken.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Runtime.Serialization;
 using GitHub.DistributedTask.Expressions2;
 using GitHub.DistributedTask.Expressions2.Sdk;
@@ -244,11 +245,11 @@ namespace GitHub.DistributedTask.ObjectTemplating.Tokens
                     break;
 
                 case ValueKind.Boolean:
-                    literal = new BooleanToken(FileId, Line, Column, (Boolean)result.Value);
+                    literal = new BooleanToken(FileId, Line, Column, (Boolean)result.Value, context.Flags.HasFlag(ExpressionFlags.DTExpressionsV1) ? String.Format(CultureInfo.InvariantCulture, "{0}", result.Value) : null);
                     break;
 
                 case ValueKind.Number:
-                    literal = new NumberToken(FileId, Line, Column, (Double)result.Value);
+                    literal = new NumberToken(FileId, Line, Column, (Double)result.Value, context.Flags.HasFlag(ExpressionFlags.DTExpressionsV1) ? ((Double)result.Value).ToString(Expressions2.Sdk.Functions.v1.Legacy.ExpressionConstants.NumberFormat, CultureInfo.InvariantCulture) : null);
                     break;
 
                 case ValueKind.String:

--- a/testworkflows/azpipelines/format-and-raw-expression-results-are-similar/pipeline.yml
+++ b/testworkflows/azpipelines/format-and-raw-expression-results-are-similar/pipeline.yml
@@ -1,0 +1,18 @@
+variables:
+  BOOL_RAW: ${{ True }}
+  BOOL_EXPECTED: ${{ format(True) }}
+  NUM_RAW: ${{ 45700000000000000000000000000 }}
+  NUM_EXPECTED: ${{ format(45700000000000000000000000000) }}
+  VER_RAW: ${{ 1.2.4.05 }}
+  VER_EXPECTED: ${{ format(1.2.4.05) }}
+
+steps:
+
+- ${{ if ne(variables.BOOL_RAW, variables.BOOL_EXPECTED) }}:
+  - Numer Format should be expected: error
+
+- ${{ if ne(variables.NUM_RAW, variables.NUM_EXPECTED) }}:
+  - Numer Format should be expected: error
+
+- ${{ if ne(variables.VER_RAW, variables.VER_EXPECTED) }}:
+  - Ver Format should be expected: error


### PR DESCRIPTION
Like
- True/False in the correct case
- Format Numbers like the decimals for raw expressions
- Use decimal parse to no longer accept GitHub Actions Number format