### PR TITLE
Add option to set the host container daemon socket location

### DIFF
--- a/src/Runner.Client/Program.cs
+++ b/src/Runner.Client/Program.cs
@@ -125,6 +125,7 @@ namespace Runner.Client
             public bool Quiet { get; set; }
             public bool Privileged { get; set; }
             public string Userns { get; set; }
+            public string ContainerDaemonSocket { get; set; }
             public string ContainerPlatform { get; set; }
             public string DefaultBranch { get; set; }
             public string Directory { get; set; }
@@ -295,6 +296,9 @@ namespace Runner.Client
                         runnerEnv["GHARUN_CHANGE_PROCESS_GROUP"] = "1";
                         if(!parameters.NoSharedToolcache && Environment.GetEnvironmentVariable("RUNNER_TOOL_CACHE") == null) {
                             runnerEnv["RUNNER_TOOL_CACHE"] = Path.Combine(GitHub.Runner.Sdk.GharunUtil.GetLocalStorage(), "tool_cache");
+                        }
+                        if(parameters.ContainerDaemonSocket != null) {
+                            runnerEnv["RUNNER_CONTAINER_DAEMON_SOCKET"] = parameters.ContainerDaemonSocket;
                         }
                         if(parameters.ContainerPlatform != null) {
                             runnerEnv["RUNNER_CONTAINER_ARCH"] = parameters.ContainerPlatform;
@@ -980,6 +984,9 @@ namespace Runner.Client
             var usernsOpt = new Option<string>(
                 "--userns",
                 "Change the docker container linux user namespace, only applies to container jobs using this Runner fork");
+            var containerDaemonSocketOpt = new Option<string>(
+                new [] { "--container-daemon-socket" },
+                "Change the docker container platform, if docker supports it. Only applies to container jobs using this Runner fork");
             var containerPlatformOpt = new Option<string>(
                 new [] { "--container-architecture", "--container-platform" },
                 "Change the docker container platform, if docker supports it. Only applies to container jobs using this Runner fork");
@@ -1098,6 +1105,7 @@ namespace Runner.Client
                 quietOpt,
                 privilegedOpt,
                 usernsOpt,
+                containerDaemonSocketOpt,
                 containerPlatformOpt,
                 keepContainerOpt,
                 DirectoryOpt,
@@ -2476,6 +2484,7 @@ namespace Runner.Client
                 parameters.Quiet = bindingContext.ParseResult.GetValueForOption(quietOpt);
                 parameters.Privileged = bindingContext.ParseResult.GetValueForOption(privilegedOpt);
                 parameters.Userns = bindingContext.ParseResult.GetValueForOption(usernsOpt);
+                parameters.ContainerDaemonSocket = bindingContext.ParseResult.GetValueForOption(containerDaemonSocketOpt);
                 parameters.ContainerPlatform = bindingContext.ParseResult.GetValueForOption(containerPlatformOpt);
                 parameters.KeepContainer = bindingContext.ParseResult.GetValueForOption(keepContainerOpt);
                 parameters.Directory = bindingContext.ParseResult.GetValueForOption(DirectoryOpt);

--- a/src/Runner.Worker/ContainerOperationProvider.cs
+++ b/src/Runner.Worker/ContainerOperationProvider.cs
@@ -273,10 +273,11 @@ namespace GitHub.Runner.Worker
 
                 if (container.IsJobContainer)
                 {
+                    var containerDaemonSocket = System.Environment.GetEnvironmentVariable("RUNNER_CONTAINER_DAEMON_SOCKET");
                     if(container.Os == "windows") {
-                        container.MountVolumes.Add(new MountVolume(@"\\.\pipe\docker_engine", @"\\.\pipe\docker_engine"));
+                        container.MountVolumes.Add(new MountVolume(containerDaemonSocket ?? @"\\.\pipe\docker_engine", @"\\.\pipe\docker_engine"));
                     } else {
-                        container.MountVolumes.Add(new MountVolume("/var/run/docker.sock", "/var/run/docker.sock"));
+                        container.MountVolumes.Add(new MountVolume(containerDaemonSocket ?? "/var/run/docker.sock", "/var/run/docker.sock"));
                     }
                 }
                 container.MountVolumes.Add(new MountVolume(HostContext.GetDirectory(WellKnownDirectory.Work), container.TranslateToContainerPath(HostContext.GetDirectory(WellKnownDirectory.Work))));

--- a/src/Runner.Worker/Handlers/ContainerActionHandler.cs
+++ b/src/Runner.Worker/Handlers/ContainerActionHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -207,13 +207,14 @@ namespace GitHub.Runner.Worker.Handlers
             var tempWorkflowDirectory = Path.Combine(tempDirectory, "_github_workflow");
             ArgUtil.Directory(tempWorkflowDirectory, nameof(tempWorkflowDirectory));
 
+            var containerDaemonSocket = System.Environment.GetEnvironmentVariable("RUNNER_CONTAINER_DAEMON_SOCKET");
             Func<string, string> mountPath;
             if(container.Os == "windows") {
                 mountPath = s => ("C:" + s).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-                container.MountVolumes.Add(new MountVolume(@"\\.\pipe\docker_engine", @"\\.\pipe\docker_engine"));
+                container.MountVolumes.Add(new MountVolume(containerDaemonSocket ?? @"\\.\pipe\docker_engine", @"\\.\pipe\docker_engine"));
             } else {
                 mountPath = s => s;
-                container.MountVolumes.Add(new MountVolume("/var/run/docker.sock", "/var/run/docker.sock"));
+                container.MountVolumes.Add(new MountVolume(containerDaemonSocket ?? "/var/run/docker.sock", "/var/run/docker.sock"));
             }
             container.MountVolumes.Add(new MountVolume(tempHomeDirectory, mountPath("/github/home")));
             container.MountVolumes.Add(new MountVolume(tempWorkflowDirectory, mountPath("/github/workflow")));


### PR DESCRIPTION
Hi there,

thanks for the wonderful initiative. This patch add the ability to set a custom location for the container daemon socket to mount into the containers, replicating act's `--container-daemon-socket`.

I am not familiar with dotnet or the project architecture so I am not sure if I did this right :-)
