### PR TITLE
azp: vscode ext bump Version to v0.2.11

### DIFF
--- a/src/azure-pipelines-vscode-ext/CHANGELOG.md
+++ b/src/azure-pipelines-vscode-ext/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v0.2.11 (Preview)
+- add iif and trim docs
+  - Now auto complete and hover should show correct content
+- fix links to docs and variables text
+- hide directive auto complete within one (block style)
+- Report Expr Syntax Errors as Fatal again in if / each body
+- clear errors if disable-auto-syntax-check is on
+
 ### v0.2.10
 - Fix syntax validation showing old errors
   - Resolves an unhandled error while the extension want to dismiss the old error messages

--- a/src/azure-pipelines-vscode-ext/package.json
+++ b/src/azure-pipelines-vscode-ext/package.json
@@ -8,7 +8,7 @@
 		"Programming Languages"
 	],
 	"icon": "pipeline-rocket.png",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"publisher": "christopherhx",
 	"repository": "https://github.com/ChristopherHX/runner.server",
 	"engines": {


### PR DESCRIPTION
- add iif and trim docs
  - Now auto complete and hover should show correct content
- fix links to docs and variables text
- hide directive auto complete within one (block style)
- Report Expr Syntax Errors as Fatal again in if / each body
- clear errors if disable-auto-syntax-check is on