### PR TITLE
azp: fix broken parameter passing in variable template

### DIFF
--- a/src/Sdk/AzurePipelines/AzureDevops.cs
+++ b/src/Sdk/AzurePipelines/AzureDevops.cs
@@ -175,7 +175,7 @@ namespace Runner.Server.Azure.Devops {
                     }
                     else if (template != null)
                     {
-                        var evalp = parameters != null && staticVarCtx != null ? await TemplateEvaluator.EvaluateAsync(staticVarCtx, "workflow-value", parameters, 0, parameters.FileId) : null;
+                        var evalp = parameters != null && staticVarCtx != null ? await TemplateEvaluator.EvaluateAsync(staticVarCtx, "workflow-value", parameters, 0, parameters.FileId) : parameters;
                         var file = await ReadTemplate(context, template, evalp != null ? evalp.AssertMapping("param").ToDictionary(kv => kv.Key.AssertString("").Value, kv => kv.Value) : null, "variable-template-root");
                         await ParseVariables(context.ChildContext(file, template), vars, (from e in file where e.Key.AssertString("").Value == "variables" select e.Value).First(), staticVarCtx);
                     }

--- a/src/azure-pipelines-vscode-ext/CHANGELOG.md
+++ b/src/azure-pipelines-vscode-ext/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v0.2.12 (Preview)
+- fix broken parameter passing in variable template
+
 ### v0.2.11 (Preview)
 - add iif and trim docs
   - Now auto complete and hover should show correct content

--- a/src/azure-pipelines-vscode-ext/package.json
+++ b/src/azure-pipelines-vscode-ext/package.json
@@ -8,7 +8,7 @@
 		"Programming Languages"
 	],
 	"icon": "pipeline-rocket.png",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"publisher": "christopherhx",
 	"repository": "https://github.com/ChristopherHX/runner.server",
 	"engines": {

--- a/testworkflows/azpipelines/variable-template-bug/pipeline.yml
+++ b/testworkflows/azpipelines/variable-template-bug/pipeline.yml
@@ -1,0 +1,11 @@
+# pipeline.yml
+variables:
+- template: variable-template-with-parameters.yml
+  parameters:
+    objectVariableName: myVariable
+    objectVariableValue: magic value
+      
+steps:
+- pwsh: exit 0
+- ${{ if ne(variables.myVariable, '"magic value"') }}:
+  - assert: This should not happen

--- a/testworkflows/azpipelines/variable-template-bug/variable-template-with-parameters.yml
+++ b/testworkflows/azpipelines/variable-template-bug/variable-template-with-parameters.yml
@@ -1,0 +1,12 @@
+# template.yml
+parameters:
+- name: objectVariableName
+  type: string
+
+- name: objectVariableValue
+  type: object
+  default: {}
+
+variables:
+- name: ${{ parameters.objectVariableName }}
+  value: ${{ convertToJson( parameters.objectVariableValue ) }}


### PR DESCRIPTION
Temporary change, should be refactored to not process variable templates twice

Closes #572
