### PR TITLE
azp: Add troubleshooting examples for Azure Pipelines in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ Error: No runner is registered for the requested runs-on labels: [ubuntu-latest]
 ```
 or this one for Azure Pipelines:
 ```
-No agent is registered for the requested capabilities: [windows-latest], please register and run a self-hosted runner with at least these capabilities
+No agent is registered for the requested capabilities: [ubuntu-latest], please register and run a self-hosted runner with at least these capabilities
 ```
 
-Then you will need to add one of the following cli options, replace `ubuntu-latest` or `windows-latest` with the content between `runs-on labels: [` The labels here without spaces `]`
+Then you will need to add one of the following cli options, replace `ubuntu-latest` with the content between `runs-on labels: [` The labels here without spaces `]` or `pool: vmImage: <capability name without spaces>` for Azure Pipelines
 - to run it on your local machine e.g. `-P ubuntu-latest=-self-hosted`, `-P self-hosted,linux,mylabel=-self-hosted`
-- to run it on your local machine with Azure Pipelines e.g. `-P windows-latest=-`
+- to run it on your local machine with Azure Pipelines e.g. `-P ubuntu-latest=-`
 - to run it in a docker container e.g. `-P ubuntu-latest=catthehacker/ubuntu:act-latest`, `-P self-hosted,linux,mylabel=catthehacker/ubuntu:act-latest`
   For more docker images refer to https://github.com/nektos/act#runners
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,14 @@ If you get an error like:
 ```
 Error: No runner is registered for the requested runs-on labels: [ubuntu-latest], please register and run a self-hosted runner with at least these labels...
 ```
+or this one for Azure Pipelines:
+```
+No agent is registered for the requested capabilities: [windows-latest], please register and run a self-hosted runner with at least these capabilities
+```
 
-Then you will need to add one of the following cli options, replace `ubuntu-latest` with the content between `runs-on labels: [` The labels here without spaces `]`
+Then you will need to add one of the following cli options, replace `ubuntu-latest` or `windows-latest` with the content between `runs-on labels: [` The labels here without spaces `]`
 - to run it on your local machine e.g. `-P ubuntu-latest=-self-hosted`, `-P self-hosted,linux,mylabel=-self-hosted`
+- to run it on your local machine with Azure Pipelines e.g. `-P windows-latest=-`
 - to run it in a docker container e.g. `-P ubuntu-latest=catthehacker/ubuntu:act-latest`, `-P self-hosted,linux,mylabel=catthehacker/ubuntu:act-latest`
   For more docker images refer to https://github.com/nektos/act#runners
 


### PR DESCRIPTION
In case of Azure Pipelines we cannot use self-hosted option for capabilities and need to replace it to empty value via CLI arguments.

I have added an example of error message and working example of the command line parameter

```
[ / Build Stage / Build Package] Running: Build Stage / Build Package
| Evaluate if
| Evaluating: succeeded()
| Evaluating succeeded:
| => true
| Result: true
| Evaluating: succeeded()
| Evaluating succeeded:
| => true
| Result: true
| Prepare Job for execution
| No agent is registered for the requested capabilities: [self-hosted], please register and run a self-hosted runner with at least these capabilities
[ / Build Stage / Build Package] Job Completed with Status: Failed
```