### PR TITLE
azp: show parameter type hover of template refs

### DIFF
--- a/src/Sdk/AzurePipelines/AzureDevops.cs
+++ b/src/Sdk/AzurePipelines/AzureDevops.cs
@@ -1007,6 +1007,25 @@ namespace Runner.Server.Azure.Devops {
                             } else {
                                 templateContext.TraceWriter.Error("{0}", $"No AutoComplete entry found for parameter list to suggest missing parameters");
                             }
+                            // Show Parameter types in Hover
+                            if(parameters != null)
+                            {
+                                for(int i = templateContext.AutoCompleteMatches.Count - 1; i >= 0; i--)
+                                {
+                                    var entry = templateContext.AutoCompleteMatches[i];
+                                    var pEntry = parameters.FirstOrDefault(kv => kv.Key == entry.Token);
+                                    if(pEntry.Key == null)
+                                    {
+                                        continue;
+                                    }
+                                    if(!dict.ContainsKey(pEntry.Key.ToString()))
+                                    {
+                                        continue;
+                                    }
+                                    entry.Description = $"Type: {dict[pEntry.Key.ToString()]}";
+                                    templateContext.TraceWriter.Error("{0}", entry.Description);
+                                }
+                            }
                         }
                     }
                     } catch (Exception ex)

--- a/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateReader.cs
+++ b/src/Sdk/DTObjectTemplating/ObjectTemplating/TemplateReader.cs
@@ -315,7 +315,7 @@ namespace GitHub.DistributedTask.ObjectTemplating
                     var nextValueDefinition = new DefinitionInfo(definition, nextValueType);
                     var last = m_context.AutoCompleteMatches?.LastOrDefault();
                     if(last != null && last.Token == nextKeyScalar) {
-                        last.Description = nextValueDefinition.Definition.Description;
+                        last.Description ??= nextValueDefinition.Definition.Description;
                     }
                     
                     var nextValue = ReadValue(nextValueDefinition);
@@ -415,7 +415,7 @@ namespace GitHub.DistributedTask.ObjectTemplating
                 var nextKeyScalar = ParseScalar(rawLiteral, keyDef);
                 var last = m_context.AutoCompleteMatches?.LastOrDefault();
                 if(last != null && last.Token == nextKeyScalar) {
-                    last.Description = valueDefinition.Definition.Description;
+                    last.Description ??= valueDefinition.Definition.Description;
                 }
 
                 // Expression

--- a/src/azure-pipelines-vscode-ext/ext-core/Program.cs
+++ b/src/azure-pipelines-vscode-ext/ext-core/Program.cs
@@ -223,7 +223,7 @@ public partial class MyClass {
                     || desc["root"].TryGetValue(tkn.RawValue, out d)
                     || desc["functions"].TryGetValue(tkn.RawValue, out d) ? d.Description : tkn.RawValue);
         }
-        return (new Runner.Server.Azure.Devops.Range { Start = last.Token.PreWhiteSpace != null ? new Position { Line = (int)last.Token.PreWhiteSpace.Line - 1, Character = (int)last.Token.PreWhiteSpace.Character - 1 } : new Position { Line = last.Token.Line.Value - 1, Character = last.Token.Column.Value - 1 }, End = new Position { Line = (int)last.Token.PostWhiteSpace.Line - 1, Character = (int)last.Token.PostWhiteSpace.Character - 1 } }, last.Definitions.FirstOrDefault()?.Description ?? "???");
+        return (new Runner.Server.Azure.Devops.Range { Start = last.Token.PreWhiteSpace != null ? new Position { Line = (int)last.Token.PreWhiteSpace.Line - 1, Character = (int)last.Token.PreWhiteSpace.Character - 1 } : new Position { Line = last.Token.Line.Value - 1, Character = last.Token.Column.Value - 1 }, End = new Position { Line = (int)last.Token.PostWhiteSpace.Line - 1, Character = (int)last.Token.PostWhiteSpace.Character - 1 } }, last?.Description ?? last.Definitions.FirstOrDefault()?.Description ?? "???");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
<img width="674" height="155" alt="image" src="https://github.com/user-attachments/assets/ac858b6c-2418-4dbe-b8c2-6fe3d3cfbf68" />

```yaml
jobs:
- ${{ if true }}:
    - template: ./template.yml
      parameters:
        x: x
- job: y
```

```yaml
parameters:
- name: x
jobs:
- job: x
```

related #644